### PR TITLE
Add SwiftUI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "outlookcalendar2jira",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "outlookcalendar2jira", targets: ["outlookcalendar2jira"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "outlookcalendar2jira",
+            path: "TimeLogger"
+        ),
+        .testTarget(
+            name: "TimeLoggerTests",
+            dependencies: ["outlookcalendar2jira"],
+            path: "Tests/TimeLoggerTests"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,10 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "outlookcalendar2jira",
-            path: "TimeLogger"
+            path: "TimeLogger",
+            linkerSettings: [
+                .linkedFramework("EventKit")
+            ]
         ),
         .testTarget(
             name: "TimeLoggerTests",

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# outlookcalendar2jira
+# Outlook Calendar to Jira
+
+This project provides a SwiftUI-based macOS application that reads Outlook meetings and logs work to Jira. The code is a minimal skeleton showing the overall structure.
+
+## Building
+
+Use Swift Package Manager with macOS 13 or later. Some components rely on frameworks unavailable on Linux, so builds must run on macOS.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Outlook Calendar to Jira
 
-This project provides a SwiftUI-based macOS application that reads Outlook meetings and logs work to Jira. The code is a minimal skeleton showing the overall structure.
+This project provides a SwiftUI-based macOS application that reads calendar events and logs work to Jira. The latest code demonstrates fetching events from the macOS Calendar using EventKit instead of Outlook. The code is a minimal skeleton showing the overall structure.
 
 ## Building
 

--- a/Tests/TimeLoggerTests/ExampleTests.swift
+++ b/Tests/TimeLoggerTests/ExampleTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import outlookcalendar2jira
+
+final class ExampleTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertTrue("ABC-123".firstJiraIssue() == "ABC-123")
+    }
+}

--- a/TimeLogger/Helpers/Regex+.swift
+++ b/TimeLogger/Helpers/Regex+.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension String {
+    func firstJiraIssue() -> String? {
+        let regex = try? NSRegularExpression(pattern: "[A-Z]+-\\d+")
+        let range = NSRange(self.startIndex..<self.endIndex, in: self)
+        let match = regex?.firstMatch(in: self, range: range)
+        if let match = match, let r = Range(match.range, in: self) {
+            return String(self[r])
+        }
+        return nil
+    }
+}

--- a/TimeLogger/Models/JiraWorklog.swift
+++ b/TimeLogger/Models/JiraWorklog.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct JiraWorklog: Encodable {
+    let started: String
+    let timeSpentSeconds: Int
+    let comment: String
+}

--- a/TimeLogger/Models/OutlookEvent.swift
+++ b/TimeLogger/Models/OutlookEvent.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct OutlookEvent: Identifiable, Decodable {
+    let id: String
+    let subject: String
+    let bodyPreview: String?
+    let start: Date
+    let end: Date
+    var overrideIssueKey: String?
+    var detectedIssueKey: String?
+}

--- a/TimeLogger/Models/Settings.swift
+++ b/TimeLogger/Models/Settings.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Combine
+
+final class Settings: ObservableObject {
+    @Published var jiraURL: String = ""
+    @Published var jiraUser: String = ""
+    @Published var jiraPassword: String = ""
+}

--- a/TimeLogger/Services/JiraService.swift
+++ b/TimeLogger/Services/JiraService.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+actor JiraService {
+    func log(worklog: JiraWorklog, to issueKey: String) async throws {
+        // TODO: implement POST to Jira API
+    }
+}

--- a/TimeLogger/Services/MacCalendarService.swift
+++ b/TimeLogger/Services/MacCalendarService.swift
@@ -1,0 +1,33 @@
+#if canImport(EventKit)
+import Foundation
+import EventKit
+
+actor MacCalendarService {
+    private let store = EKEventStore()
+
+    func fetchEvents(start: Date, end: Date) async throws -> [OutlookEvent] {
+        try await store.requestAccess(to: .event)
+        let predicate = store.predicateForEvents(withStart: start, end: end, calendars: nil)
+        let events = store.events(matching: predicate)
+        return events.map { event in
+            OutlookEvent(
+                id: event.eventIdentifier,
+                subject: event.title ?? "",
+                bodyPreview: event.notes,
+                start: event.startDate,
+                end: event.endDate,
+                overrideIssueKey: nil,
+                detectedIssueKey: event.title?.firstJiraIssue()
+            )
+        }
+    }
+}
+#else
+import Foundation
+
+actor MacCalendarService {
+    func fetchEvents(start: Date, end: Date) async throws -> [OutlookEvent] {
+        return []
+    }
+}
+#endif

--- a/TimeLogger/Services/OutlookService.swift
+++ b/TimeLogger/Services/OutlookService.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+actor OutlookService {
+    func fetchEvents(start: Date, end: Date) async throws -> [OutlookEvent] {
+        // TODO: implement Graph API fetching with MSAL
+        return []
+    }
+}

--- a/TimeLogger/TimeLoggerApp.swift
+++ b/TimeLogger/TimeLoggerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TimeLoggerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/TimeLogger/ViewModels/EventListVM.swift
+++ b/TimeLogger/ViewModels/EventListVM.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class EventListVM: ObservableObject {
+    @Published var rows: [OutlookEvent] = []
+    private let outlookService = OutlookService()
+
+    func refresh(start: Date, end: Date) async {
+        do {
+            rows = try await outlookService.fetchEvents(start: start, end: end)
+        } catch {
+            // TODO: handle error
+        }
+    }
+}

--- a/TimeLogger/ViewModels/EventListVM.swift
+++ b/TimeLogger/ViewModels/EventListVM.swift
@@ -4,11 +4,11 @@ import SwiftUI
 @MainActor
 final class EventListVM: ObservableObject {
     @Published var rows: [OutlookEvent] = []
-    private let outlookService = OutlookService()
+    private let calendarService = MacCalendarService()
 
     func refresh(start: Date, end: Date) async {
         do {
-            rows = try await outlookService.fetchEvents(start: start, end: end)
+            rows = try await calendarService.fetchEvents(start: start, end: end)
         } catch {
             // TODO: handle error
         }

--- a/TimeLogger/Views/ContentView.swift
+++ b/TimeLogger/Views/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var vm = EventListVM()
+
+    var body: some View {
+        Text("Hello World")
+            .frame(minWidth: 800, minHeight: 400)
+            .task {
+                let today = Date()
+                await vm.refresh(start: today, end: today)
+            }
+    }
+}

--- a/TimeLogger/Views/SettingsView.swift
+++ b/TimeLogger/Views/SettingsView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var settings: Settings
+
+    var body: some View {
+        Form {
+            TextField("Jira URL", text: $settings.jiraURL)
+            TextField("Username", text: $settings.jiraUser)
+            SecureField("Password", text: $settings.jiraPassword)
+        }
+        .padding()
+    }
+}


### PR DESCRIPTION
## Summary
- create Swift package with macOS target
- add SwiftUI skeleton and placeholders for services
- add a basic regex helper and example unit test
- update README with build notes

## Testing
- `swift build` *(fails: no such module 'Combine')*
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68420d0a416c8330b8a9b703220131ee