### PR TITLE
Add macOS Calendar Service

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,10 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "outlookcalendar2jira",
-            path: "TimeLogger"
+            path: "TimeLogger",
+            linkerSettings: [
+                .linkedFramework("EventKit")
+            ]
         ),
         .testTarget(
             name: "TimeLoggerTests",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Outlook Calendar to Jira
 
-This project provides a SwiftUI-based macOS application that reads Outlook meetings and logs work to Jira. The code is a minimal skeleton showing the overall structure.
+This project provides a SwiftUI-based macOS application that reads calendar events and logs work to Jira. The latest code demonstrates fetching events from the macOS Calendar using EventKit instead of Outlook. The code is a minimal skeleton showing the overall structure.
 
 ## Building
 

--- a/TimeLogger/Services/MacCalendarService.swift
+++ b/TimeLogger/Services/MacCalendarService.swift
@@ -1,0 +1,33 @@
+#if canImport(EventKit)
+import Foundation
+import EventKit
+
+actor MacCalendarService {
+    private let store = EKEventStore()
+
+    func fetchEvents(start: Date, end: Date) async throws -> [OutlookEvent] {
+        try await store.requestAccess(to: .event)
+        let predicate = store.predicateForEvents(withStart: start, end: end, calendars: nil)
+        let events = store.events(matching: predicate)
+        return events.map { event in
+            OutlookEvent(
+                id: event.eventIdentifier,
+                subject: event.title ?? "",
+                bodyPreview: event.notes,
+                start: event.startDate,
+                end: event.endDate,
+                overrideIssueKey: nil,
+                detectedIssueKey: event.title?.firstJiraIssue()
+            )
+        }
+    }
+}
+#else
+import Foundation
+
+actor MacCalendarService {
+    func fetchEvents(start: Date, end: Date) async throws -> [OutlookEvent] {
+        return []
+    }
+}
+#endif

--- a/TimeLogger/ViewModels/EventListVM.swift
+++ b/TimeLogger/ViewModels/EventListVM.swift
@@ -4,11 +4,11 @@ import SwiftUI
 @MainActor
 final class EventListVM: ObservableObject {
     @Published var rows: [OutlookEvent] = []
-    private let outlookService = OutlookService()
+    private let calendarService = MacCalendarService()
 
     func refresh(start: Date, end: Date) async {
         do {
-            rows = try await outlookService.fetchEvents(start: start, end: end)
+            rows = try await calendarService.fetchEvents(start: start, end: end)
         } catch {
             // TODO: handle error
         }


### PR DESCRIPTION
## Summary
- replace OutlookService usage with new MacCalendarService
- add MacCalendarService using EventKit
- link EventKit framework
- update README about macOS Calendar

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6842150c06ac8330acfb4374b7a27739