### PR TITLE
Fix event store isolation

### DIFF
--- a/TimeLogger/Services/MacCalendarService.swift
+++ b/TimeLogger/Services/MacCalendarService.swift
@@ -3,7 +3,7 @@ import Foundation
 import EventKit
 
 actor MacCalendarService {
-    private let store = EKEventStore()
+    nonisolated(unsafe) let store = EKEventStore()
 
     func fetchEvents(start: Date, end: Date) async throws -> [OutlookEvent] {
         try await store.requestAccess(to: .event)


### PR DESCRIPTION
## Summary
- mark `MacCalendarService.store` as `nonisolated(unsafe)` to avoid Sendable errors

## Testing
- `swift build` *(fails: no such module `Combine`)*
- `swift test` *(fails: no such module `Combine`)*

------
https://chatgpt.com/codex/tasks/task_e_684217cf384c83308ebded06eb4a9c19