### PR TITLE
Fix event list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Outlook Calendar to Jira
 
-This project provides a SwiftUI-based macOS application that reads calendar events and logs work to Jira. The latest code demonstrates fetching events from the macOS Calendar using EventKit instead of Outlook. The code is a minimal skeleton showing the overall structure.
+This project provides a SwiftUI-based macOS application that reads calendar events and logs work to Jira. The application fetches events from the macOS Calendar using EventKit instead of Outlook. When launched, it now displays today's meetings in a table.
 
 ## Building
 

--- a/TimeLogger/Views/ContentView.swift
+++ b/TimeLogger/Views/ContentView.swift
@@ -4,11 +4,21 @@ struct ContentView: View {
     @StateObject private var vm = EventListVM()
 
     var body: some View {
-        Text("Hello World")
-            .frame(minWidth: 800, minHeight: 400)
-            .task {
-                let today = Date()
-                await vm.refresh(start: today, end: today)
+        Table(vm.rows) {
+            TableColumn("Start") { event in
+                Text(event.start.formatted(date: .numeric, time: .shortened))
             }
+            TableColumn("End") { event in
+                Text(event.end.formatted(date: .numeric, time: .shortened))
+            }
+            TableColumn("Subject", value: \.subject)
+        }
+        .frame(minWidth: 800, minHeight: 400)
+        .task {
+            let calendar = Calendar.current
+            let start = calendar.startOfDay(for: Date())
+            let end = calendar.date(byAdding: .day, value: 1, to: start)!
+            await vm.refresh(start: start, end: end)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show today's meetings in a table
- document that the app shows today's meetings

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68421956396083308a18391dfe431da3