### PR TITLE
Fix sendable settings in Jira logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ This project provides a SwiftUI-based macOS application that reads calendar even
 ## Building
 
 Use Swift Package Manager with macOS 13 or later. Some components rely on frameworks unavailable on Linux, so builds must run on macOS.
+
+## Local Jira for testing
+
+A simple `docker-compose.yml` is included for running Jira locally. Start the
+container with:
+
+```bash
+docker compose up -d
+```
+
+The container exposes Jira on `http://localhost:8080` with default credentials
+`admin`/`admin`. The application is preconfigured to use these credentials.

--- a/TimeLogger/Models/JiraConfig.swift
+++ b/TimeLogger/Models/JiraConfig.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct JiraConfig: Sendable {
+    let url: String
+    let user: String
+    let password: String
+}
+
+extension Settings {
+    var config: JiraConfig {
+        JiraConfig(url: jiraURL, user: jiraUser, password: jiraPassword)
+    }
+}

--- a/TimeLogger/Models/OutlookEvent.swift
+++ b/TimeLogger/Models/OutlookEvent.swift
@@ -8,4 +8,14 @@ struct OutlookEvent: Identifiable, Decodable {
     let end: Date
     var overrideIssueKey: String?
     var detectedIssueKey: String?
+    var logged: Bool = false
+
+    var issueKey: String {
+        get { overrideIssueKey ?? detectedIssueKey ?? "" }
+        set { overrideIssueKey = newValue }
+    }
+
+    var duration: TimeInterval {
+        end.timeIntervalSince(start)
+    }
 }

--- a/TimeLogger/Models/Settings.swift
+++ b/TimeLogger/Models/Settings.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 
 final class Settings: ObservableObject {
-    @Published var jiraURL: String = ""
-    @Published var jiraUser: String = ""
-    @Published var jiraPassword: String = ""
+    @Published var jiraURL: String = "http://localhost:8080"
+    @Published var jiraUser: String = "admin"
+    @Published var jiraPassword: String = "admin"
 }

--- a/TimeLogger/Services/JiraService.swift
+++ b/TimeLogger/Services/JiraService.swift
@@ -1,7 +1,15 @@
 import Foundation
 
 actor JiraService {
-    func log(worklog: JiraWorklog, to issueKey: String) async throws {
-        // TODO: implement POST to Jira API
+    func log(worklog: JiraWorklog, to issueKey: String, config: JiraConfig) async throws {
+        guard let url = URL(string: "\(config.url)/rest/api/2/issue/\(issueKey)/worklog") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let authString = "\(config.user):\(config.password)".data(using: .utf8)!.base64EncodedString()
+        request.addValue("Basic \(authString)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder().encode(worklog)
+
+        _ = try await URLSession.shared.data(for: request)
     }
 }

--- a/TimeLogger/Services/MacCalendarService.swift
+++ b/TimeLogger/Services/MacCalendarService.swift
@@ -10,14 +10,15 @@ actor MacCalendarService {
         let predicate = store.predicateForEvents(withStart: start, end: end, calendars: nil)
         let events = store.events(matching: predicate)
         return events.map { event in
-            OutlookEvent(
+            let detected = event.notes?.firstJiraIssue() ?? event.title?.firstJiraIssue()
+            return OutlookEvent(
                 id: event.eventIdentifier,
                 subject: event.title ?? "",
                 bodyPreview: event.notes,
                 start: event.startDate,
                 end: event.endDate,
                 overrideIssueKey: nil,
-                detectedIssueKey: event.title?.firstJiraIssue()
+                detectedIssueKey: detected
             )
         }
     }

--- a/TimeLogger/ViewModels/EventListVM.swift
+++ b/TimeLogger/ViewModels/EventListVM.swift
@@ -5,12 +5,34 @@ import SwiftUI
 final class EventListVM: ObservableObject {
     @Published var rows: [OutlookEvent] = []
     private let calendarService = MacCalendarService()
+    private let jira = JiraService()
+    let settings = Settings()
 
     func refresh(start: Date, end: Date) async {
         do {
             rows = try await calendarService.fetchEvents(start: start, end: end)
         } catch {
             // TODO: handle error
+        }
+    }
+
+    func logAll() async {
+        for index in rows.indices {
+            guard !rows[index].logged else { continue }
+            let key = rows[index].issueKey
+            guard !key.isEmpty else { continue }
+            let worklog = JiraWorklog(
+                started: ISO8601DateFormatter().string(from: rows[index].start),
+                timeSpentSeconds: Int(rows[index].duration),
+                comment: rows[index].subject
+            )
+            do {
+                let config = settings.config
+                try await jira.log(worklog: worklog, to: key, config: config)
+                rows[index].logged = true
+            } catch {
+                // TODO: handle error
+            }
         }
     }
 }

--- a/TimeLogger/Views/ContentView.swift
+++ b/TimeLogger/Views/ContentView.swift
@@ -4,16 +4,33 @@ struct ContentView: View {
     @StateObject private var vm = EventListVM()
 
     var body: some View {
-        Table(vm.rows) {
-            TableColumn("Start") { event in
-                Text(event.start.formatted(date: .numeric, time: .shortened))
+        VStack {
+            Table($vm.rows) {
+                TableColumn("Start") { $row in
+                    Text(row.wrappedValue.start.formatted(date: .numeric, time: .shortened))
+                }
+                TableColumn("End") { $row in
+                    Text(row.wrappedValue.end.formatted(date: .numeric, time: .shortened))
+                }
+                TableColumn("Duration") { $row in
+                    Text(row.wrappedValue.duration.formatted())
+                }
+                TableColumn("Subject") { $row in
+                    Text(row.wrappedValue.subject)
+                }
+                TableColumn("Jira Issue") { $row in
+                    TextField("", text: Binding(
+                        get: { row.wrappedValue.issueKey },
+                        set: { row.wrappedValue.issueKey = $0 }
+                    ))
+                }
             }
-            TableColumn("End") { event in
-                Text(event.end.formatted(date: .numeric, time: .shortened))
+            .frame(minWidth: 800, minHeight: 400)
+
+            Button("Log All") {
+                Task { await vm.logAll() }
             }
-            TableColumn("Subject", value: \.subject)
         }
-        .frame(minWidth: 800, minHeight: 400)
         .task {
             let calendar = Calendar.current
             let start = calendar.startOfDay(for: Date())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  jira:
+    image: cptactionhank/atlassian-jira-software:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - JIRA_USERNAME=admin
+      - JIRA_PASSWORD=admin


### PR DESCRIPTION
## Summary
- snapshot settings into a `JiraConfig` sendable struct
- update `JiraService` to use the config object
- adapt `EventListVM` to pass a settings snapshot

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68421d642eb88330b715b334854e6e46